### PR TITLE
Add support for on-prem Windows authentication

### DIFF
--- a/PolicyStorageService/PackageRoot/ServiceManifest.xml
+++ b/PolicyStorageService/PackageRoot/ServiceManifest.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <ServiceManifest Name="PolicyStorageServicePkg"
-                 Version="1.0.0"
+                 Version="1.1.0"
                  xmlns="http://schemas.microsoft.com/2011/01/fabric"
                  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
@@ -11,7 +11,7 @@
   </ServiceTypes>
 
   <!-- Code package is your service executable. -->
-  <CodePackage Name="Code" Version="1.0.0">
+  <CodePackage Name="Code" Version="1.1.0">
     <EntryPoint>
       <ExeHost>
         <Program>PolicyStorageService.exe</Program>

--- a/PolicyStorageService/Utility.cs
+++ b/PolicyStorageService/Utility.cs
@@ -103,7 +103,7 @@ namespace RestoreService
         {
             HttpClient client;
 
-            if (URL.Contains("https://") && certThumbprint != null && certThumbprint != "NotExist")
+            if (URL.Contains("https://") && certThumbprint != null && certThumbprint != "NotExist" && certThumbprint != "WindowsCredentials")
             {
                 X509Certificate2 clientCert = GetClientCertificate(certThumbprint);
                 WebRequestHandler requestHandler = new WebRequestHandler();
@@ -113,7 +113,7 @@ namespace RestoreService
             }
             else
             {
-                client = new HttpClient();
+                client = certThumbprint == "WindowsCredentials" ? new HttpClient(new HttpClientHandler() { UseDefaultCredentials = true }) : new HttpClient();
             }
 
             client.BaseAddress = new Uri(URL);
@@ -139,7 +139,7 @@ namespace RestoreService
         {
             HttpClient client;
 
-            if (URL.Contains("https://") && certThumbprint != null && certThumbprint != "NotExist")
+            if (URL.Contains("https://") && certThumbprint != null && certThumbprint != "NotExist" && certThumbprint != "WindowsCredentials")
             {
                 X509Certificate2 clientCert = GetClientCertificate(certThumbprint);
                 WebRequestHandler requestHandler = new WebRequestHandler();
@@ -149,7 +149,7 @@ namespace RestoreService
             }
             else
             {
-                client = new HttpClient();
+                client = certThumbprint == "WindowsCredentials" ? new HttpClient(new HttpClientHandler() { UseDefaultCredentials = true }) : new HttpClient();
             }
 
             client.BaseAddress = new Uri(URL);
@@ -228,14 +228,14 @@ namespace RestoreService
 
             try
             {
-                if (thumbprint != null && cname != null && thumbprint != "NotExist" && cname != "NotExist")
+                if (thumbprint != null && cname != null && thumbprint != "NotExist" && cname != "NotExist" && thumbprint != "WindowsCredentials" && cname != "WindowsCredentials")
                 {
                     var xc = GetCredentials(thumbprint, thumbprint, cname);
                     fc = new FabricClient(xc, connectionEndpoint);
                 }
                 else
                 {
-                    fc = new FabricClient(connectionEndpoint);
+                    fc = thumbprint == "WindowsCredentials" ? new FabricClient(new WindowsCredentials(), connectionEndpoint) : new FabricClient(connectionEndpoint);
                 }
 
                 return fc;

--- a/RestoreService/PackageRoot/ServiceManifest.xml
+++ b/RestoreService/PackageRoot/ServiceManifest.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <ServiceManifest Name="RestoreServicePkg"
-                 Version="1.0.0"
+                 Version="1.1.0"
                  xmlns="http://schemas.microsoft.com/2011/01/fabric"
                  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
@@ -11,7 +11,7 @@
   </ServiceTypes>
 
   <!-- Code package is your service executable. -->
-  <CodePackage Name="Code" Version="1.0.0">
+  <CodePackage Name="Code" Version="1.1.0">
     <EntryPoint>
       <ExeHost>
         <Program>RestoreService.exe</Program>

--- a/SFAppDRToolApplication/ApplicationPackageRoot/ApplicationManifest.xml
+++ b/SFAppDRToolApplication/ApplicationPackageRoot/ApplicationManifest.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<ApplicationManifest xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ApplicationTypeName="SFAppDRTool" ApplicationTypeVersion="1.0.0" xmlns="http://schemas.microsoft.com/2011/01/fabric">
+<ApplicationManifest xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ApplicationTypeName="SFAppDRTool" ApplicationTypeVersion="1.1.0" xmlns="http://schemas.microsoft.com/2011/01/fabric">
   <Parameters>
     <Parameter Name="PolicyStorageService_MinReplicaSetSize" DefaultValue="3" />
     <Parameter Name="PolicyStorageService_PartitionCount" DefaultValue="1" />
@@ -15,7 +15,7 @@
        should match the Name and Version attributes of the ServiceManifest element defined in the 
        ServiceManifest.xml file. -->
   <ServiceManifestImport>
-    <ServiceManifestRef ServiceManifestName="PolicyStorageServicePkg" ServiceManifestVersion="1.0.0" />
+    <ServiceManifestRef ServiceManifestName="PolicyStorageServicePkg" ServiceManifestVersion="1.1.0" />
     <ConfigOverrides>
       <ConfigOverride Name="Config">
         <Settings>
@@ -27,7 +27,7 @@
     </ConfigOverrides>
   </ServiceManifestImport>
   <ServiceManifestImport>
-    <ServiceManifestRef ServiceManifestName="WebInterfacePkg" ServiceManifestVersion="1.0.0" />
+    <ServiceManifestRef ServiceManifestName="WebInterfacePkg" ServiceManifestVersion="1.1.0" />
     <ConfigOverrides>
       <ConfigOverride Name="Config">
         <Settings>
@@ -42,7 +42,7 @@
     </Policies>
   </ServiceManifestImport>
   <ServiceManifestImport>
-    <ServiceManifestRef ServiceManifestName="RestoreServicePkg" ServiceManifestVersion="1.0.0" />
+    <ServiceManifestRef ServiceManifestName="RestoreServicePkg" ServiceManifestVersion="1.1.0" />
     <ConfigOverrides>
       <ConfigOverride Name="Config">
         <Settings>

--- a/WebInterface/PackageRoot/ServiceManifest.xml
+++ b/WebInterface/PackageRoot/ServiceManifest.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <ServiceManifest Name="WebInterfacePkg"
-                 Version="1.0.0"
+                 Version="1.1.0"
                  xmlns="http://schemas.microsoft.com/2011/01/fabric"
                  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
@@ -11,7 +11,7 @@
   </ServiceTypes>
 
   <!-- Code package is your service executable. -->
-  <CodePackage Name="Code" Version="1.0.0">
+  <CodePackage Name="Code" Version="1.1.0">
     <EntryPoint>
       <ExeHost>
         <Program>WebInterface.exe</Program>

--- a/WebInterface/Views/Home/Applications.cshtml
+++ b/WebInterface/Views/Home/Applications.cshtml
@@ -42,15 +42,24 @@
                         <small class="text-muted">To connect to the primary cluster</small>
                     </div>
                     <div class="form-group">
+                        <label>
+                            <input type="checkbox" ng-model="primaryUseWindowsCredentials"
+                                   data-role="hint"
+                                   data-hint-position="left"
+                                   data-hint-text="Please select if windows credentials are to be used to connect to the primary cluster." />
+                            Use Windows Credentials
+                        </label>
+                    </div>
+                    <div class="form-group">
                         <label>Secure Thumbprint</label>
-                        <input type="text" placeholder="012345678901234567890123456789" ng-model="primSecureThumbp" ng-disabled="primaryClusterHTTPEndpoint.includes('http://')"
+                        <input type="text" placeholder="012345678901234567890123456789" ng-model="primSecureThumbp" ng-disabled="primaryClusterHTTPEndpoint.includes('http://') || primaryUseWindowsCredentials"
                                data-role="hint"
                                data-hint-position="left"
                                data-hint-text="Please enter the secure certificate thumbprint to connect to your primary cluster." />
                     </div>
                     <div class="form-group">
                         <label>Common Name</label>
-                        <input type="text" placeholder="westus.cloudapp.azure.com" ng-model="primaryCommonName" ng-disabled="primaryClusterHTTPEndpoint.includes('http://')"
+                        <input type="text" placeholder="westus.cloudapp.azure.com" ng-model="primaryCommonName" ng-disabled="primaryClusterHTTPEndpoint.includes('http://') || primaryUseWindowsCredentials"
                                data-role="hint"
                                data-hint-position="left"
                                data-hint-text="Please enter the common name of your certificate to connect to your primary cluster." />
@@ -77,15 +86,23 @@
                         <small class="text-muted">To connect to the secondary cluster</small>
                     </div>
                     <div class="form-group">
+                        <label data-role="hint"
+                               data-hint-position="left"
+                               data-hint-text="Please select if windows credentials are to be used to connect to the primary cluster.">
+                            <input type="checkbox" ng-model="secondaryUseWindowsCredentials" />
+                            Use Windows Credentials
+                        </label>
+                    </div>
+                    <div class="form-group">
                         <label>Secure Thumbprint</label>
-                        <input type="text" placeholder="012345678901234567890123456789" ng-model="secSecureThumbp" ng-disabled="secondaryClusterHTTPEndpoint.includes('http://')"
+                        <input type="text" placeholder="012345678901234567890123456789" ng-model="secSecureThumbp" ng-disabled="secondaryClusterHTTPEndpoint.includes('http://') || secondaryUseWindowsCredentials"
                                data-role="hint"
                                data-hint-position="left"
                                data-hint-text="Please enter the secure certificate thumbprint to connect to your secondary cluster." />
                     </div>
                     <div class="form-group">
                         <label>Common Name</label>
-                        <input type="text" placeholder="westus.cloudapp.azure.com" ng-model="secondaryCommonName" ng-disabled="secondaryClusterHTTPEndpoint.includes('http://')"
+                        <input type="text" placeholder="westus.cloudapp.azure.com" ng-model="secondaryCommonName" ng-disabled="secondaryClusterHTTPEndpoint.includes('http://') || secondaryUseWindowsCredentials"
                                data-role="hint"
                                data-hint-position="left"
                                data-hint-text="Please enter the common name of your certificate to connect to your secondary cluster." />

--- a/WebInterface/wwwroot/js/site.js
+++ b/WebInterface/wwwroot/js/site.js
@@ -539,14 +539,22 @@ app.controller('SFAppDRToolController', ['$rootScope', '$scope', '$http', '$time
             return;
         }
 
-        if ($scope.primaryClusterHTTPEndpoint.includes("http://")) {
+        if ($scope.primaryUseWindowsCredentials) {
+            $rootScope.primaryClusterThumbprint = "WindowsCredentials";
+            $rootScope.primaryClusterCommonName = "WindowsCredentials";
+        }
+        else if ($scope.primaryClusterHTTPEndpoint.includes("http://")) {
             $rootScope.primaryClusterThumbprint = "NotExist";
             $rootScope.primaryClusterCommonName = "NotExist";
         }
 
-        if ($scope.secondaryClusterHTTPEndpoint.includes("http://")) {
+        if ($scope.secondaryUseWindowsCredentials) {
+            $rootScope.secondaryClusterThumbprint = "WindowsCredentials";
+            $rootScope.secondaryClusterCommonName = "WindowsCredentials";
+        }
+        else if ($scope.secondaryClusterHTTPEndpoint.includes("http://")) {
             $rootScope.secondaryClusterThumbprint = "NotExist";
-            $rootScope.secondaryClusterCommonName = "NotExist"
+            $rootScope.secondaryClusterCommonName = "NotExist";
         }
 
         if (!$scope.validateClusterDetails()) {
@@ -557,7 +565,7 @@ app.controller('SFAppDRToolController', ['$rootScope', '$scope', '$http', '$time
         $location.path("/servConfig").search('rt', Math.random());
         $rootScope.splashLoad = true;
 
-        $http.get('api/RestoreService/apps/' + $scope.primaryClusterEndpoint + '/' + $scope.primSecureThumbp + '/' + $scope.primaryCommonName + '/' + $scope.secondaryClusterEndpoint + '/' + $scope.secSecureThumbp + '/' + $scope.secondaryCommonName)
+        $http.get('api/RestoreService/apps/' + $scope.primaryClusterEndpoint + '/' + $rootScope.primaryClusterThumbprint + '/' + $rootScope.primaryClusterCommonName + '/' + $scope.secondaryClusterEndpoint + '/' + $rootScope.secondaryClusterThumbprint + '/' + $rootScope.secondaryClusterCommonName)
             .then(function (data, status) {
                 $rootScope.splashLoad = false;
                 $scope.apps = data;
@@ -644,6 +652,8 @@ app.controller('SFAppDRToolController', ['$rootScope', '$scope', '$http', '$time
         $scope.secSecureThumbp = secondaryCluster.certificateThumbprint;
         $scope.primaryCommonName = primaryCluster.commonName;
         $scope.secondaryCommonName = secondaryCluster.commonName;
+        $scope.primaryUseWindowsCredentials = primaryCluster.certificateThumbprint === "WindowsCredentials";
+        $scope.secondaryUseWindowsCredentials = secondaryCluster.certificateThumbprint === "WindowsCredentials";
         $scope.getAppsOnPrimaryCluster();
     }
 


### PR DESCRIPTION
As the title says, support for on-prem active directory authentication. Similar to how insecure cluster configuration piggybacks on the cert thumbprint having a magic value of "NotExist", this uses a magic value of "WindowsCredentials"